### PR TITLE
Add dev-container CI and Cortex-enabled Pi 5 image

### DIFF
--- a/.github/workflows/dev-container.yml
+++ b/.github/workflows/dev-container.yml
@@ -1,0 +1,55 @@
+name: Build Dev Container
+
+on:
+  push:
+    branches: [main, develop]
+    paths:
+      - "cortex/**"
+      - "infra/containers/dev/**"
+
+concurrency:
+  group: dev-container-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-push:
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/koalbymqp/zaraos-dev
+          tags: |
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            type=raw,value=nightly,enable=${{ github.ref == 'refs/heads/develop' }}
+            type=sha,prefix=,format=short
+
+      - name: Set up Buildx (Blacksmith)
+        uses: useblacksmith/setup-buildx@v1
+
+      - name: Build and push dev container
+        uses: useblacksmith/build-push-action@v2
+        with:
+          context: .
+          file: infra/containers/dev/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=registry,ref=ghcr.io/koalbymqp/zaraos-dev:buildcache
+          cache-to: type=registry,ref=ghcr.io/koalbymqp/zaraos-dev:buildcache,mode=max


### PR DESCRIPTION
## Summary
- Added a GitHub Actions workflow to build and push the dev container image to GHCR with branch-based `latest` and `nightly` tags.
- Updated the devcontainer to build from the local Dockerfile and start via the new container bootstrap script.
- Expanded the ZaraOS Pi 5 image for the Cortex stack, container runtime, node exporter, OTA/update flow, and first-boot data partition setup.
- Added the new `cortex` service, API/registry implementation, example apps, and related Buildroot package and overlay wiring.
- Removed outdated local build docs and replaced the old single-image release flow with compressed `sdcard.img.gz` artifacts.

## Testing
- Not run (changes were not validated in this workspace).
- Verify the dev container builds successfully from `.devcontainer.json` and starts `infra/containers/dev/start.sh`.
- Verify `.github/workflows/dev-container.yml` publishes images with the expected `latest`, `nightly`, and SHA tags.
- Verify the Buildroot defconfig still resolves all added packages and generates a bootable Pi 5 image.
- Verify first boot mounts `/boot` and `/data`, expands the data partition, and remounts containerd storage correctly.
- Verify `cortex` starts from the `S60-cortex.sh` init script and the API is reachable on the expected port.